### PR TITLE
Fix license error when install from GitHub

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 torch==1.3.1
-tqdm==4.41.1
+tqdm==4.31.0
 transformers==2.3.0
 numpy==1.16.3
 pandas==0.25.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ log_cli_level = WARNING
 
 [metadata]
 description-file = README.md
-license_file = LICENSE.txt
+license_file = LICENSE
 
 [pycodestyle]
 max-line-length = 88


### PR DESCRIPTION
`setup.cfg` reference to `LICENSE.txt` that doesn't exist and produce an error when installing from GitHub. Re-referenced to `LICENSE`.