### PR TITLE
Makedir fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.2+melior1.1.3] - 2019-01-29
+### Fixed
+- `os.mkdir` replaced to `os.makedirs` to create all the intermediate directories
+
 ## [0.18.2+melior1.1.2] - 2019-01-27
 ### Fixed
 - `shutil.rmtree` error not handled

--- a/melior_transformers/classification/classification_model.py
+++ b/melior_transformers/classification/classification_model.py
@@ -838,7 +838,7 @@ class ClassificationModel:
             output_mode = "classification"
 
         if not os.path.isdir(self.args["cache_dir"]):
-            os.mkdir(self.args["cache_dir"])
+            os.makedirs(self.args["cache_dir"])
 
         mode = "dev" if evaluate else "train"
         cached_features_file = os.path.join(

--- a/melior_transformers/classification/classification_utils.py
+++ b/melior_transformers/classification/classification_utils.py
@@ -460,6 +460,7 @@ def delete_worst_models(args, results_path):
         epoch_path = os.path.join(args["output_dir"], item[0])
         if os.path.exists(epoch_path):
             try:
+                print(f"Removing {epoch_path}.")
                 shutil.rmtree(epoch_path, onerror=del_rw)
             except Exception as e:
                 print(f"Error when removing {epoch_path}. \n {e}")

--- a/melior_transformers/experimental/classification/classification_model.py
+++ b/melior_transformers/experimental/classification/classification_model.py
@@ -612,7 +612,7 @@ class ClassificationModel:
         args = self.args
 
         if not os.path.isdir(self.args["cache_dir"]):
-            os.mkdir(self.args["cache_dir"])
+            os.makedirs(self.args["cache_dir"])
 
         mode = "dev" if evaluate else "train"
         cached_features_file = os.path.join(

--- a/melior_transformers/ner/ner_model.py
+++ b/melior_transformers/ner/ner_model.py
@@ -744,7 +744,7 @@ class NERModel:
         )
 
         if not os.path.isdir(self.args["cache_dir"]):
-            os.mkdir(self.args["cache_dir"])
+            os.makedirs(self.args["cache_dir"])
 
         if os.path.exists(cached_features_file) and (
             (not args["reprocess_input_data"] and not no_cache)

--- a/melior_transformers/question_answering/question_answering_model.py
+++ b/melior_transformers/question_answering/question_answering_model.py
@@ -143,7 +143,7 @@ class QuestionAnsweringModel:
         args = self.args
 
         if not os.path.isdir(self.args["cache_dir"]):
-            os.mkdir(self.args["cache_dir"])
+            os.makedirs(self.args["cache_dir"])
 
         examples = get_examples(examples, is_training=not evaluate)
 
@@ -674,7 +674,7 @@ class QuestionAnsweringModel:
 
         prefix = "test"
         if not os.path.isdir(output_dir):
-            os.mkdir(output_dir)
+            os.makedirs(output_dir)
 
         output_prediction_file = os.path.join(
             output_dir, "predictions_{}.json".format(prefix)

--- a/melior_transformers/version.py
+++ b/melior_transformers/version.py
@@ -1,1 +1,1 @@
-__version__ = "0.18.2+melior1.1.2"
+__version__ = "0.18.2+melior1.1.3"


### PR DESCRIPTION
As long as `cache_dir` and `output_dir` can be configured, if the path doesn't exist, should be created. 

changed from `mkdir()` to `makedirs()` because the second one creates all the intermediate directories.